### PR TITLE
Removed external library dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@ drawille-plusplus
 
 An implementation of [drawille](https://github.com/asciimoo/drawille) in C++.
 
-Currently depends on the ICU library for unicode support.
+Do not forget to set your locale with `std::locale::global(std::locale(""));` at the beginning of your program to enable wide-character support.
 
-Header-only, to use in your project simply include `drawille.hpp` and compile with `-licuuc -licuio`.
+Header-only, to use in your project simply include `drawille.hpp` and compile with C++11 support or later.
 
 I may write more examples at a later date, or you are free to contribute some via pull request.
 

--- a/drawille.hpp
+++ b/drawille.hpp
@@ -3,21 +3,19 @@
 
 #include <vector>
 #include <ostream>
-#include <unicode/ustream.h>
-#include <unicode/unistr.h>
 
 namespace Drawille {
   using std::vector;
-  using std::ostream;
+  using std::wostream;
 
-  const size_t pixmap[4][2] = {
+  constexpr size_t pixmap[4][2] = {
     {0x01, 0x08},
     {0x02, 0x10},
     {0x04, 0x20},
     {0x40, 0x80}
   };
 
-  const size_t braille = 0x2800;
+  constexpr wchar_t braille = 0x2800;
 
   class Canvas {
   public:
@@ -39,18 +37,18 @@ namespace Drawille {
       this->canvas[y / 4][x / 2] &= ~pixmap[y % 4][x % 2];
     }
 
-    void draw(ostream& strm) {
+    void draw(wostream& strm) {
       for(auto& v: this->canvas) {
         for(auto& c: v) {
           if(c == 0) strm << " ";
-          else strm << UnicodeString((UChar32)(braille+c));
+          else strm << std::wstring{braille+c};
         }
         strm << std::endl;
       }
     }
 
   protected:
-    vector<vector<size_t>> canvas;
+    vector<vector<wchar_t>> canvas;
   };
 }
 

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,10 +1,9 @@
 CXX?=g++
 CXXFLAGS=-Wall -Werror -pedantic -std=c++14
-LDFLAGS=-licuuc -licuio
 all:
 	for f in *.cpp ; do \
 		echo "Compiling $$f..."; \
-		$(CXX) $$f -o `basename $$f .cpp`".out" $(CXXFLAGS) $(LDFLAGS); \
+		$(CXX) $$f -o `basename $$f .cpp`".out" $(CXXFLAGS); \
 	done;
 
 clean:

--- a/examples/line.cpp
+++ b/examples/line.cpp
@@ -1,17 +1,20 @@
 #include <iostream>
+#include <locale>
 #include "../drawille.hpp"
 
 using namespace Drawille;
-using std::cout;
+using std::wcout;
+using std::locale;
 
-int main(int argc, char **argv) {
+int main() {
+  locale::global(locale(""));
   Canvas canvas(80, 24);
 
   for(int i = 0; i <= 10; ++i) {
     canvas.set(i, i);
   }
 
-  canvas.draw(cout);
+  canvas.draw(wcout);
 
   return 0;
 }


### PR DESCRIPTION
Since C++ now supports unicode in the STL, I removed the external library
dependency, the only side effect being that you need to properly set your
locale for `wchar_t` and  `std::wostream` to work as intended.

I also changed `pixmap` to a `constexpr` so it doesn't need to exist at runtime.
